### PR TITLE
Win10 20H2 console pasting

### DIFF
--- a/AppLogic/Helpers/AttachedThreadInputScope.cs
+++ b/AppLogic/Helpers/AttachedThreadInputScope.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using System.Text;
 using System.Threading;
 
 namespace AppLogic.Helpers
@@ -39,9 +40,16 @@ namespace AppLogic.Helpers
             if (_currentThreadId != _foregroundThreadId)
             {
                 // attach to the foreground thread
-                if (!WinApi.AttachThreadInput(_foregroundThreadId, _currentThreadId, true))
+                if (!WinApi.AttachThreadInput(_currentThreadId, _foregroundThreadId, true))
                 {
-                    return;
+                    // unable to attach, see if the window is a Win10 Console Window
+                    var className = new StringBuilder(capacity: 256);
+                    WinApi.GetClassName(_foregroundWindow, className, className.Capacity - 1);
+                    if (String.CompareOrdinal("ConsoleWindowClass", className.ToString()) != 0)
+                    {
+                        return;
+                    }
+                    // consider attached to a console window
                 }
             }
 
@@ -58,7 +66,7 @@ namespace AppLogic.Helpers
                     _attached = false;
                     if (_currentThreadId != _foregroundThreadId)
                     {
-                        WinApi.AttachThreadInput(_foregroundThreadId, _currentThreadId, false);
+                        WinApi.AttachThreadInput(_currentThreadId, _foregroundThreadId, false);
                     }
                 }
             }

--- a/Tests/CategoryTraceListener.cs
+++ b/Tests/CategoryTraceListener.cs
@@ -22,28 +22,28 @@ namespace Tests
             _categoty = categoty;
         }
 
-        public override void Write(string message)
+        public override void Write(string? message)
         {
         }
 
-        public override void WriteLine(string message)
+        public override void WriteLine(string? message)
         {
         }
 
         public override bool IsThreadSafe => true;
 
-        public override void WriteLine(string message, string category)
+        public override void WriteLine(string? message, string? category)
         {
             lock (_lock)
             {
                 if (String.CompareOrdinal(category, _categoty) == 0)
                 {
-                    _list.Add(message);
+                    _list.Add(message ?? String.Empty);
                 }
             }
         }
 
-        public override void Write(string message, string category)
+        public override void Write(string? message, string? category)
         {
             WriteLine(message, category);
         }


### PR DESCRIPTION
Discovered that pasting with <kbd>Win</kbd>+<kbd>Ins</kbd> stopped working in Windows 10 v20H2 (build 19042.630). 
Turned out, [`AttachThreadInput`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-attachthreadinput) API now returns `FALSE` when trying to attach to the foreground  thread of an active console app. 

As a workaround, [`SendInput`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput) appears to work fine with console apps, without attaching thread inputs.