### PR TITLE
Win+Alt+Ins, built-in Notepad

### DIFF
--- a/AppLogic/AppLogic.csproj
+++ b/AppLogic/AppLogic.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.9.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
 

--- a/AppLogic/Helpers/StringExtensions.cs
+++ b/AppLogic/Helpers/StringExtensions.cs
@@ -29,6 +29,11 @@ namespace AppLogic.Helpers
             return @this.Replace("\n", Environment.NewLine);
         }
 
+        public static string RemoveSpaces(this string @this)
+        {
+            return String.Concat(@this.Where(c => !Char.IsWhiteSpace(c)));
+        }
+
         public static string TrimTrailingEmptyLines(this string @this)
         {
             var regex = new Regex(@"^\s*$", RegexOptions.Singleline);

--- a/AppLogic/Presenter/HotkeyHandlerHost.cs
+++ b/AppLogic/Presenter/HotkeyHandlerHost.cs
@@ -580,19 +580,18 @@ namespace AppLogic.Presenter
             var notepad = new Notepad(this.Token);
 
             notepad.ControlEnterPressed += (s, e) =>
-                PasteFromNotepadAsync().IgnoreCancellations();
+                SaveNotepadToClipboard().IgnoreCancellations();
 
             return notepad;
 
-            async Task PasteFromNotepadAsync()
+            async Task SaveNotepadToClipboard()
             {
                 using var _lock = await WithLockAsync();
                 var text = notepad!.EditorText;
                 notepad!.Hide();
                 if (text.IsNotNullNorEmpty())
                 {
-                    await InputHelpers.InputYield(token: this.Token);
-                    await (this as IHotkeyHandlerHost).FeedTextAsync(text, this.Token);
+                    Clipboard.SetText(text, TextDataFormat.UnicodeText);
                 }
             }
         }

--- a/AppLogic/Presenter/PredefinedHotkeyHandlers.cs
+++ b/AppLogic/Presenter/PredefinedHotkeyHandlers.cs
@@ -11,6 +11,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -68,6 +69,18 @@ namespace AppLogic.Presenter
                 .UnixifyLineEndings()
                 .TrimTrailingEmptyLines()
                 .ConvertToSingleLine();
+
+            await Host.FeedTextAsync(text, token);
+            Host.PlayNotificationSound();
+        }
+
+        /// <summary>
+        /// Remove formatting, spaces and paste as single line
+        /// </summary>
+        [HotkeyHandler]
+        public async Task PasteAsSingleLineNoSpaces(Hotkey _, CancellationToken token)
+        {
+            var text = GetClipboardText().RemoveSpaces();
 
             await Host.FeedTextAsync(text, token);
             Host.PlayNotificationSound();

--- a/DevComrade/App.config
+++ b/DevComrade/App.config
@@ -25,6 +25,7 @@
     <hotkey name="PasteUnindented" menuItem="Paste Unindented" mods="0x9" vkey="'V'" />
     <hotkey name="PasteUnindentedUntabified" menuItem="Paste Unindented, Untabified" mods="0x9" vkey="'Z'" />
     <hotkey name="PasteAsSingleLine" menuItem="Paste as Single Line" mods="0x8" vkey="0x2D" />
+    <hotkey name="PasteAsSingleLineNoSpaces" menuItem="Paste as Single Line No Spaces" mods="0x9" vkey="0x2D" />
     <hotkey name="PasteToNotepad" menuItem="Paste to Internal Notepad" mods="0x1" vkey="0x2D" />
     <hotkey name="OpenNotepad" menuItem="Open Internal Notepad" mods="0x8" vkey="0xDC" />
     <hotkey name="OpenUrl" menuItem="&amp;Open URL from Clipboard" mods="0xC" vkey="'O'" />

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   - Press <kbd>Alt</kbd>+<kbd>Ins</kbd> to edit the Clipboard text with DevComrade's built-in Notepad.
   - Press <kbd>Control</kbd>+<kbd>Enter</kbd> to close the built-in Notepad and save its content into the Clipboard.
   - Press <kbd>Esc</kbd> to close it without saving.
-- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Ins</kbd> to paste text with all spaces and line-breaks removed (e.g., for pasting a credit card or bank account details).  
+- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Ins</kbd> to paste text with all spaces and line-breaks removed (e.g., for pasting a credit card or bank account details). As a reminder, <kbd>Win</kbd>+<kbd>Ins</kbd> pastes with only line-breaks removed.
 - Updated to use .NET 5.0
 
 # Introduction

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 # What's new
 
-- Simply use <kbd>Ctrl</kbd>+<kbd>V</kbd> for pasting plain text system-wide. Or whatever is the default keyboard shortcut / menu command for pasting in the currently active Windows application.<br>
-`DevComrade` now monitors Windows Clipboard for text with rich formatting and replaces it with plain text by default (using [Win32 Clipboard Monitoring API](https://docs.microsoft.com/en-us/windows/win32/dataxchg/using-the-clipboard#monitoring-clipboard-contents)). This enables pasting plain text by default for *all* Windows applications using their native UI and keyboard bindings. It can be controlled by the <kbd>Win</kbd>+<kbd>F10</kbd> menu or via the [`.config` file](https://github.com/postprintum/devcomrade/blob/main/DevComrade/App.config).
-- You can now press <kbd>Control</kbd>+<kbd>Enter</kbd> to hide the Internal Notepad (invoked with <kbd>Alt</kbd>+<kbd>Ins</kbd>) and paste its content into the currently active application.
+- Simply use <kbd>Ctrl</kbd>+<kbd>V</kbd> for pasting plain text system-wide (or any other default keyboard shortcut / menu command for pasting, specific to your currently open application).
+<br>`DevComrade` now monitors Windows Clipboard for text with rich formatting and replaces it with plain text by default (using [Win32 Clipboard Monitoring API](https://docs.microsoft.com/en-us/windows/win32/dataxchg/using-the-clipboard#monitoring-clipboard-contents)). This behavior can be controlled by the <kbd>Win</kbd>+<kbd>F10</kbd> menu or via the [`.config` file](https://github.com/postprintum/devcomrade/blob/main/DevComrade/App.config).
+- The buit-in Clipboard Notepad:
+  - Press <kbd>Alt</kbd>+<kbd>Ins</kbd> to edit the Clipboard text with DevComrade's built-in Notepad.
+  - Press <kbd>Control</kbd>+<kbd>Enter</kbd> to close the built-in Notepad and save its content into the Clipboard.
+  - Press <kbd>Esc</kbd> to close it without saving.
+- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Ins</kbd> to paste text with all spaces and line-breaks removed (e.g., for pasting a credit card or bank account details).  
 - Updated to use .NET 5.0
 
 # Introduction
@@ -40,7 +44,7 @@ When it comes to pasting text, `DevComrade` is different from many similar utili
 
 # To try it out from the source code: 
 
-- Download and install [.NET 5.0 SDK](https://download.visualstudio.microsoft.com/download/pr/674a9f7d-862e-4f92-91b6-f1cf3fed03ce/e07db4de77ada8da2c23261dfe9db138/dotnet-sdk-5.0.103-win-x64.exe), if you haven't got it already. That's the only needed prerequisite tool. Visual Studio or Visual Studio Code aren't required to build this app.
+- Download and install [.NET 5.0 SDK](https://download.visualstudio.microsoft.com/download/pr/475b587c-e586-4187-8feb-a602f3c6b449/b82433e88760e76d2ab591530e0784b9/dotnet-sdk-5.0.300-win-x64.exe), if you haven't got it installed already. That's the only needed prerequisite tool. Visual Studio or Visual Studio Code aren't required to build this app.
 
 - Download and unzip [the source](https://github.com/postprintum/devcomrade/archive/main.zip), or use `git` to clone the repo to a folder of your choice, e.g.:
     ```


### PR DESCRIPTION
- The buit-in Clipboard Notepad improved:
  - Press <kbd>Alt</kbd>+<kbd>Ins</kbd> to edit the Clipboard text with DevComrade's built-in Notepad.
  - Press <kbd>Control</kbd>+<kbd>Enter</kbd> to close the built-in Notepad and save its content into the Clipboard.
  - Press <kbd>Esc</kbd> to close it without saving.
- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Ins</kbd> to paste text with all spaces and line-breaks removed (e.g., for pasting a credit card or bank account details). 
- As a reminder, <kbd>Win</kbd>+<kbd>Ins</kbd> pastes with only line-breaks removed.
